### PR TITLE
Fix to support HTTP/2 status lines

### DIFF
--- a/lib/webmock/http_lib_adapters/patron_adapter.rb
+++ b/lib/webmock/http_lib_adapters/patron_adapter.rb
@@ -118,7 +118,7 @@ if defined?(::Patron)
         def self.build_webmock_response(patron_response)
           webmock_response = WebMock::Response.new
           reason = patron_response.status_line.
-            scan(%r(\AHTTP/(\d+\.\d+)\s+(\d\d\d)\s*([^\r\n]+)?))[0][2]
+            scan(%r(\AHTTP/(\d+(?:\.\d+)?)\s+(\d\d\d)\s*([^\r\n]+)?))[0][2]
           webmock_response.status = [patron_response.status, reason]
           webmock_response.body = patron_response.body
           webmock_response.headers = patron_response.headers


### PR DESCRIPTION
The regular expression applied to the HTTP status line only supports strings starting with "HTTP/x.x". However, HTTP/2 status lines won't use the dot.